### PR TITLE
Plot/output fixes: legend, log-scale, ggplot R-export

### DIFF
--- a/server/13_0_run_lineplot.R
+++ b/server/13_0_run_lineplot.R
@@ -146,28 +146,29 @@ CreatePlot <- function(modelResults,
   
   # use gather on incoming results to put them into a plottable data structure
   selectedData <- gatherData(modelResults, concentrations)
-  n <- length(unique(selectedData$Variable))
-  
-  # gather vector of selected line type inputs and evaluate to vector
-  type_line <- paste0("c(", 
-                      paste0("input$line_type", 
-                            unique(sort(selectedData$Variable)), 
-                            collapse = ", "),
-                      ")"
-                )
-  
-  type_line <- eval(parse(text = type_line))
-  
+  # Ensure the Variable factor levels preserve the requested order from
+  # `concentrations` (if provided) so that legend order and color/linetype
+  # mappings remain consistent between on-screen and downloaded plots.
+  if (!is.null(concentrations)) {
+    levs <- intersect(concentrations, unique(selectedData$Variable))
+    if (length(levs) == 0) levs <- unique(selectedData$Variable)
+  } else {
+    levs <- unique(selectedData$Variable)
+  }
+  selectedData$Variable <- factor(selectedData$Variable, levels = levs)
+  n <- length(levs)
+
+    # Build the linetype vector in the same order as the factor levels.
+    id_names <- gsub(" ", "_", levels(selectedData$Variable))
+    type_line <- paste0("c(", paste0("input$line_type", id_names, collapse = ", "), ")")
+    type_line <- eval(parse(text = type_line))
+
   # Find selected color palletes and create
   cols_line <- color_palettes(colorPalette, n)
   # rewrite with the custom values if user chose custom
   if (cols_line[1] == "CUSTOM") {
-    cols_line <-
-      paste0("c(",
-             paste0("input$cols_line", 
-                    unique(sort(selectedData$Variable)), 
-                    collapse = ", "),
-             ")")
+    cols_ids <- gsub(" ", "_", levels(selectedData$Variable))
+    cols_line <- paste0("c(", paste0("input$cols_line", cols_ids, collapse = ", "), ")")
     cols_line <- eval(parse(text = cols_line))
   }
   
@@ -209,12 +210,12 @@ CreatePlot <- function(modelResults,
   g_line <- g_line + 
     # Select the colors of the lines
     scale_color_manual(name = legendTitle,
-                       values = cols_line,
-                       labels = unique(selectedData$Variable)) +
+               values = cols_line,
+               labels = levels(selectedData$Variable)) +
     # Select the show type of the lines
     scale_linetype_manual(name = legendTitle,
-                          values = type_line,
-                          labels = unique(selectedData$Variable)) +
+                values = type_line,
+                labels = levels(selectedData$Variable)) +
     #this adds title, xlabel, and ylabel to graph based upon text inputs
     labs(
       title = plotTitle,
@@ -310,24 +311,21 @@ CreatePlot <- function(modelResults,
 plotLineplotInput <- function(data) {
   #calls data function and stores it to selectedData
   selectedData <- data
-  n = length(unique(selectedData$Variable))
-  #n = length(unique(selectedData$variable))
-  type_line <-
-    paste0("c(", paste0("input$line_type", 
-                        unique(sort(data$Variable)), 
-                        collapse = ", "), ")")
+  # Preserve ordering of variables as they appear so legend order matches
+  # the plotted traces.
+  levs <- unique(selectedData$Variable)
+  selectedData$Variable <- factor(selectedData$Variable, levels = levs)
+  n = length(levs)
+  id_names <- gsub(" ", "_", levels(selectedData$Variable))
+  type_line <- paste0("c(", paste0("input$line_type", id_names, collapse = ", "), ")")
   type_line <- eval(parse(text = type_line))
   #create vector of cols for lines
-  
+
   cols_line <- color_palettes(input$choose_color_palette, n)
   # rewrite with the custom values if user chose custom
   if (cols_line[1] == "CUSTOM") {
-    cols_line <-
-      paste0("c(",
-             paste0("input$cols_line", 
-                    unique(sort(data$Variable)), 
-                    collapse = ", "),
-             ")")
+    cols_ids <- gsub(" ", "_", levels(selectedData$Variable))
+    cols_line <- paste0("c(", paste0("input$cols_line", cols_ids, collapse = ", "), ")")
     cols_line <- eval(parse(text = cols_line))
   }
   
@@ -339,9 +337,11 @@ plotLineplotInput <- function(data) {
     #scale_fill_brewer(palette = "Dark2") + 
     #scale_color_viridis(discrete = FALSE, option = "D") + 
     scale_color_manual(name = input$line_legend_title,
-                       values = cols_line) +
+               values = cols_line,
+               labels = levels(selectedData$Variable)) +
     scale_linetype_manual(name = input$line_legend_title,
-                          values = type_line)
+                values = type_line,
+                labels = levels(selectedData$Variable))
   
   if (input$line_show_dots) {
     g_line <- g_line + geom_point()

--- a/server/13_0_run_lineplot.R
+++ b/server/13_0_run_lineplot.R
@@ -89,7 +89,9 @@ CreatePlot <- function(modelResults,
                        optionOverlayData,
                        dataToOverlay, 
                        overlayX,
-                       overlayY
+                       overlayY,
+                       optionXLogScale = FALSE,
+                       optionYLogScale = FALSE
 
 ) {
   # Inputs
@@ -249,23 +251,55 @@ CreatePlot <- function(modelResults,
   
   # Options for Custom Axis Choices
   if (optionCustomAxis) {
-    g_line <-
-      g_line + scale_x_continuous(
-        limits = c(xAxisMin, xAxisMax),
-        breaks = seq(
-          from = xAxisMin,
-          to = xAxisMax,
-          by = xAxisStep
+    if (optionXLogScale && xAxisMin > 0) {
+      # Use log scale with custom limits
+      g_line <-
+        g_line + scale_x_log10(
+          limits = c(xAxisMin, xAxisMax)
         )
-      ) +
-      scale_y_continuous(
-        limits = c(yAxisMin, yAxisMax),
-        breaks = seq(
-          from = yAxisMin,
-          to = yAxisMax,
-          by = yAxisStep
+    } else if (optionXLogScale) {
+      # Log scale requested but min <= 0, use default log scale
+      g_line <- g_line + scale_x_log10()
+    } else {
+      g_line <-
+        g_line + scale_x_continuous(
+          limits = c(xAxisMin, xAxisMax),
+          breaks = seq(
+            from = xAxisMin,
+            to = xAxisMax,
+            by = xAxisStep
+          )
         )
-      )
+    }
+
+    if (optionYLogScale && yAxisMin > 0) {
+      # Use log scale with custom limits
+      g_line <-
+        g_line + scale_y_log10(
+          limits = c(yAxisMin, yAxisMax)
+        )
+    } else if (optionYLogScale) {
+      # Log scale requested but min <= 0, use default log scale
+      g_line <- g_line + scale_y_log10()
+    } else {
+      g_line <-
+        g_line + scale_y_continuous(
+          limits = c(yAxisMin, yAxisMax),
+          breaks = seq(
+            from = yAxisMin,
+            to = yAxisMax,
+            by = yAxisStep
+          )
+        )
+    }
+  } else {
+    # Apply log scales even when custom axis is not enabled
+    if (optionXLogScale) {
+      g_line <- g_line + scale_x_log10()
+    }
+    if (optionYLogScale) {
+      g_line <- g_line + scale_y_log10()
+    }
   }
   
   if (is.null(concentrations)) {
@@ -351,25 +385,55 @@ plotLineplotInput <- function(data) {
   }
   
   if (input$line_axis_confirm) {
-    g_line <-
-      g_line + scale_x_continuous(
-        limits = c(input$line_xaxis_min, input$line_xaxis_max),
-        breaks = seq(
-          from = input$line_xaxis_min,
-          to = input$line_xaxis_max,
-          by = input$line_xstep
+    if (input$line_xaxis_log && input$line_xaxis_min > 0) {
+      # Use log scale with custom limits
+      g_line <-
+        g_line + scale_x_log10(
+          limits = c(input$line_xaxis_min, input$line_xaxis_max)
         )
-      ) +
-      scale_y_continuous(
-        limits = c(input$line_yaxis_min, input$line_yaxis_max),
-        breaks = seq(
-          input$line_yaxis_min,
-          input$line_yaxis_max,
-          input$line_ystep
+    } else if (input$line_xaxis_log) {
+      # Log scale requested but min <= 0, use default log scale
+      g_line <- g_line + scale_x_log10()
+    } else {
+      g_line <-
+        g_line + scale_x_continuous(
+          limits = c(input$line_xaxis_min, input$line_xaxis_max),
+          breaks = seq(
+            from = input$line_xaxis_min,
+            to = input$line_xaxis_max,
+            by = input$line_xstep
+          )
         )
-      )
-  } else{
-    g_line <- g_line
+    }
+
+    if (input$line_yaxis_log && input$line_yaxis_min > 0) {
+      # Use log scale with custom limits
+      g_line <-
+        g_line + scale_y_log10(
+          limits = c(input$line_yaxis_min, input$line_yaxis_max)
+        )
+    } else if (input$line_yaxis_log) {
+      # Log scale requested but min <= 0, use default log scale
+      g_line <- g_line + scale_y_log10()
+    } else {
+      g_line <-
+        g_line + scale_y_continuous(
+          limits = c(input$line_yaxis_min, input$line_yaxis_max),
+          breaks = seq(
+            input$line_yaxis_min,
+            input$line_yaxis_max,
+            input$line_ystep
+          )
+        )
+    }
+  } else {
+    # Apply log scales even when custom axis is not enabled
+    if (input$line_xaxis_log) {
+      g_line <- g_line + scale_x_log10()
+    }
+    if (input$line_yaxis_log) {
+      g_line <- g_line + scale_y_log10()
+    }
   }
   
   if (is.null(input$lineplot_yvar)) {
@@ -629,7 +693,9 @@ output$main_lineplot <- renderPlot({
                           input$show_overlay_data,
                           data.scatter(),
                           input$plot_data_import_x,
-                          input$plot_data_import_y)
+                          input$plot_data_import_y,
+                          input$line_xaxis_log,
+                          input$line_yaxis_log)
     return(to.plot)
   } else {
     plot(1, 1, type="n", xlab="", ylab="", xaxt='n', yaxt='n')
@@ -674,7 +740,9 @@ output$lineplot_plotly <- renderPlotly({
                           input$show_overlay_data,
                           data.scatter(),
                           input$plot_data_import_x,
-                          input$plot_data_import_y
+                          input$plot_data_import_y,
+                          input$line_xaxis_log,
+                          input$line_yaxis_log
     )
     ggplotly(to.plot,
              tooltip = c("x", "y", "colour"))

--- a/server/write_R.R
+++ b/server/write_R.R
@@ -33,7 +33,7 @@ CreateRModel <- function(variables, parameters, parameterValues, ICsValues,
                          additionalEqns, diffEQs, timeScaleBool, timeScaleValue,
                          solverMethod, timeStart, timeEnd, timeStep){
   
-  out.script <- "library(deSolve)\n\n"
+  out.script <- "library(deSolve)\nlibrary(ggplot2)\nlibrary(reshape2)\n\n"
   
   start.function <- "myModel <- function(t, state, parameters) {\n "
   start.function <- paste0(start.function,
@@ -67,7 +67,21 @@ CreateRModel <- function(variables, parameters, parameterValues, ICsValues,
   
   ode.line <- paste0("\nout <- ode(y = state, times = times, func = myModel, ",
                      "parms = parameters)\n")
-  
+
+  # Build plotting code
+  plot.code <- "\nout_df <- as.data.frame(out)\n\n"
+  plot.code <- paste0(plot.code, "# Convert to long format for ggplot\n")
+  plot.code <- paste0(plot.code, "out_long <- melt(out_df, id.vars = \"time\",\n")
+  plot.code <- paste0(plot.code, "                 variable.name = \"species\",\n")
+  plot.code <- paste0(plot.code, "                 value.name = \"value\")\n\n")
+  plot.code <- paste0(plot.code, "ggplot(out_long, aes(x = time, y = value, color = species)) +\n")
+  plot.code <- paste0(plot.code, "  geom_line(size = 1.2) +\n")
+  plot.code <- paste0(plot.code, "  theme_bw() +\n")
+  plot.code <- paste0(plot.code, "  labs(title = \"ODE Model Dynamics\",\n")
+  plot.code <- paste0(plot.code, "       x = \"Time\",\n")
+  plot.code <- paste0(plot.code, "       y = \"Concentration\",\n")
+  plot.code <- paste0(plot.code, "       color = \"Species\")\n")
+
   #build output script from components above
   out.script <- paste0(out.script, start.function)
   if (!is.na(add.eqns)) 
@@ -78,7 +92,8 @@ CreateRModel <- function(variables, parameters, parameterValues, ICsValues,
   out.script <- paste0(out.script, state)
   out.script <- paste0(out.script, times)
   out.script <- paste0(out.script, ode.line)
-  
+  out.script <- paste0(out.script, plot.code)
+
   return(out.script)
 
   

--- a/ui/13_run_lineplot_ui.R
+++ b/ui/13_run_lineplot_ui.R
@@ -263,6 +263,18 @@ TAB_RUN_LINEPLOT <- tabItem(
               )
             )
           ), #end fluidRow
+          hr(),
+          prettyCheckbox(
+            inputId = "line_xaxis_log",
+            label = "Log Scale X-Axis",
+            value = FALSE
+          ),
+          prettyCheckbox(
+            inputId = "line_yaxis_log",
+            label = "Log Scale Y-Axis",
+            value = FALSE
+          ),
+          hr(),
           switchInput(
             inputId = "line_axis_confirm",
             label = "Change Axis",


### PR DESCRIPTION
# What's included (3 commits)
- `7b449d4` feat: add ggplot plotting code to exported R script
  (BTB `750b6f7`). Generated R script gains `library(ggplot2)`,
  `library(reshape2)`, plus a `melt` + `geom_line` plot block.
- `8e3e1b0` fix: preserve legend order in downloaded plot
  (BTB `6f6ef25`). `CreatePlot()` and `plotLineplotInput()` build a
  `Variable` factor with explicit levels in the order requested by
  `concentrations`, then use `levels(...)` consistently for
  color/linetype/label assignment so values, labels, and factor
  levels stay in lockstep.
- `f68acb6` feat: add log-scale toggle to lineplot axes
  (log-scale portion of BTB `5c8508f` only — see note).

## Important note on BTB `5c8508f`
The upstream commit titled "added log scale of plot" is actually a
**bundled commit** containing two unrelated features:
1. Log scale (~150 lines, two files) — what this PR ports.
2. An unrelated "krel relative-formation" feature for
   `degradation_by_enzyme` reactions (~460 lines, four files,
   plus ~30 leftover `print("DEBUG: ...")` statements).

Only the log-scale half is in this PR. The krel feature is deferred
to a separate future PR after the debug prints are stripped.
